### PR TITLE
add .gcloudignore, gunicorn, and adjust port for deploy

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# Ignore virtual environment directory
+venv/
+
+# Ignore compiled Python files
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore cache directories
+__pycache__/
+.cache/
+
+# Ignore logs
+logs/
+
+# Ignore temporary files
+*.tmp
+
+# Ignore configuration files
+config.ini

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,9 @@
 runtime: python39
 
-entrypoint: gunicorn -b :$PORT main:app
+env_variables:
+  PORT: '8080'
+
+entrypoint: gunicorn -b :$PORT --timeout=300 main:app
 
 runtime_config:
   python_version: 3.9

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
 from flask_mysqldb import MySQL
+import os
+
 
 app = Flask(__name__)
 
@@ -12,3 +14,7 @@ app.config['MYSQL_CURSORCLASS'] = 'DictCursor'
 mysql = MySQL(app)
 
 from app import routes
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/main.py
+++ b/main.py
@@ -1,1 +1,4 @@
 from app import app
+
+if __name__ == '__main__':
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click==8.1.3
 colorama==0.4.6
 Flask==2.3.2
 Flask-MySQLdb==1.0.1
+gunicorn
 itsdangerous==2.1.2
 Jinja2==3.1.2
 joblib==1.2.0


### PR DESCRIPTION
Add .gcloudignore for limiting deployment of virtualenv so it's not exceed App engine limit quotas.

gunicorn for python app engine deployment.

adjusting port for Recommend API to not being collided with Backend API in the terms of port access.

Thank you for sharing Your GitHub with me.